### PR TITLE
Bump Scala and dependencies versions

### DIFF
--- a/bin/s3-encrypt
+++ b/bin/s3-encrypt
@@ -2,7 +2,7 @@
 
 basedir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/..
 version=$(sed -e 's/ *version *:= *"\(.*\)" */\1/p' -n $basedir/build.sbt)
-jar=$basedir/target/scala-2.11/s3-encrypt-assembly-$version.jar
+jar=$basedir/target/scala-2.13/s3-encrypt-assembly-$version.jar
 
 if [ ! -e "$jar" ]; then
   pushd $basedir

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.11.8"
+scalaVersion := "2.13.3"
 
 version := "0.1"
 
@@ -6,6 +6,6 @@ libraryDependencies ++= Seq("s3", "kms").map(module =>
   "com.amazonaws" % s"aws-java-sdk-$module" % "1.11.30"
 )
 libraryDependencies ++= Seq(
-  "com.github.scopt" %% "scopt" % "3.5.0",
-  "commons-io" % "commons-io" % "2.5"
+  "com.github.scopt" %% "scopt" % "3.7.1",
+  "commons-io" % "commons-io" % "2.7"
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")


### PR DESCRIPTION
When trying to run s3-encrypt I saw the error:
```
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	::          UNRESOLVED DEPENDENCIES         ::
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	:: com.eed3si9n#sbt-assembly;0.14.3: not found
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
```

I thought the simplest fix would be to bump the Scala, libraries and plugin versions.  Pleasantly surprised by how few libraries it uses!